### PR TITLE
Merge job notification, delete job, and docker build arg feature branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+flask_ades_wpst/__pycache__/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ RUN git clone https://github.com/hysds/otello.git && \
 
 # RUN git clone -b MCP_TEST https://github.com/unity-sds/unity-sps-register_job.git
 # RUN git clone -b deploy-process https://github.com/drewm-jpl/unity-sps-register_job.git
-
+COPY requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
 WORKDIR /flask_ades_wpst
 COPY . /flask_ades_wpst
 # write otello config to ~/.config/otello/config.yml'?

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,8 @@ RUN git clone https://github.com/hysds/otello.git && \
 
 # RUN git clone -b MCP_TEST https://github.com/unity-sds/unity-sps-register_job.git
 # RUN git clone -b deploy-process https://github.com/drewm-jpl/unity-sps-register_job.git
+COPY requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
 
 WORKDIR /flask_ades_wpst
 COPY . /flask_ades_wpst

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -3,7 +3,7 @@ from jinja2 import Template
 import logging
 import json
 from utils.job_publisher import SnsJobPublisher
-from utils.datatypes import Job, JobStatus
+from utils.datatypes import Job
 from flask_ades_wpst.sqlite_connector import sqlite_get_procs, sqlite_get_proc, sqlite_deploy_proc, \
     sqlite_undeploy_proc, sqlite_get_jobs, sqlite_get_job, sqlite_exec_job, sqlite_dismiss_job, \
     sqlite_update_job_status
@@ -33,7 +33,7 @@ class ADES_Base:
             raise ValueError("Platform {} not implemented.".\
                              format(self._platform))
         self._ades = ADES_Platform()
-        self._job_publisher = SnsJobPublisher(app_config["JOB_NOTIFICATION_TOPIC_NAME"])
+        self._job_publisher = SnsJobPublisher(app_config["JOB_NOTIFICATION_TOPIC_ARN"])
         
     def proc_dict(self, proc):
         return {"id": proc[0],

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -4,15 +4,23 @@ import logging
 import json
 from utils.job_publisher import SnsJobPublisher
 from utils.datatypes import Job, JobStatus
-from flask_ades_wpst.sqlite_connector import sqlite_get_procs, sqlite_get_proc, sqlite_deploy_proc, \
-    sqlite_undeploy_proc, sqlite_get_jobs, sqlite_get_job, sqlite_exec_job, sqlite_dismiss_job, \
-    sqlite_update_job_status
+from flask_ades_wpst.sqlite_connector import (
+    sqlite_get_procs,
+    sqlite_get_proc,
+    sqlite_deploy_proc,
+    sqlite_undeploy_proc,
+    sqlite_get_jobs,
+    sqlite_get_job,
+    sqlite_exec_job,
+    sqlite_dismiss_job,
+    sqlite_update_job_status,
+)
 from datetime import datetime
 
 log = logging.getLogger(__name__)
 
-class ADES_Base:
 
+class ADES_Base:
     def __init__(self, app_config):
         self.host = "http://127.0.0.1:5000"
         self._app_config = app_config
@@ -30,37 +38,38 @@ class ADES_Base:
             # platform here, you must also add it to the valid_platforms
             # tuple default argument to the flask_wpst function in
             # flask_wpst.py.
-            raise ValueError("Platform {} not implemented.".\
-                             format(self._platform))
+            raise ValueError("Platform {} not implemented.".format(self._platform))
         self._ades = ADES_Platform()
-        self._job_publisher = SnsJobPublisher(app_config["JOB_NOTIFICATION_TOPIC_NAME"])
-        
+        self._job_publisher = SnsJobPublisher(app_config["JOBS_DATA_SNS_TOPIC_ARN"])
+
     def proc_dict(self, proc):
-        return {"id": proc[0],
-                "title": proc[1],
-                "abstract": proc[2],
-                "keywords": proc[3],
-                "owsContextURL": proc[4],
-                "inputs": json.loads(proc[5]),
-                "outputs": json.loads(proc[6]),
-                "processVersion": proc[7],
-                "jobControlOptions": proc[8].split(','),
-                "outputTransmission": proc[9].split(','),
-                "immediateDeployment": str(bool(proc[9])).lower(),
-                "executionUnit": proc[10]}
-    
+        return {
+            "id": proc[0],
+            "title": proc[1],
+            "abstract": proc[2],
+            "keywords": proc[3],
+            "owsContextURL": proc[4],
+            "inputs": json.loads(proc[5]),
+            "outputs": json.loads(proc[6]),
+            "processVersion": proc[7],
+            "jobControlOptions": proc[8].split(","),
+            "outputTransmission": proc[9].split(","),
+            "immediateDeployment": str(bool(proc[9])).lower(),
+            "executionUnit": proc[10],
+        }
+
     def get_procs(self):
         saved_procs = sqlite_get_procs()
         procs = [self.proc_dict(saved_proc) for saved_proc in saved_procs]
         return procs
-    
+
     def get_proc(self, proc_id):
         """
         TODO: sqlite_get_proc vulnerable to sql injeciton through proc_id
         """
         saved_proc = sqlite_get_proc(proc_id)
         return self.proc_dict(saved_proc)
-    
+
     def deploy_proc(self, req_proc):
         """
         DONE
@@ -70,34 +79,36 @@ class ADES_Base:
         print(req_proc)
         proc_desc = req_proc["processDescription"]
         proc = proc_desc["process"]
-        proc_id = proc['id']
+        proc_id = proc["id"]
         # proc_id = f"{proc['id']}-{proc_desc['processVersion']}"
-        proc_title = proc['title']
-        proc_abstract = proc['abstract']
-        proc_keywords = proc['keywords']
-        proc_version = proc_desc['processVersion']
-        job_control = proc_desc['jobControlOptions']
+        proc_title = proc["title"]
+        proc_abstract = proc["abstract"]
+        proc_keywords = proc["keywords"]
+        proc_version = proc_desc["processVersion"]
+        job_control = proc_desc["jobControlOptions"]
         proc_desc_url = "{}/processes/{}".format(self.host, f"{proc_id}:{proc_version}")
 
         # creating response
         proc_summ = dict()
-        proc_summ['id'] = proc_id
-        proc_summ['title'] = proc_title
-        proc_summ['abstract'] = proc_abstract
-        proc_summ['keywords'] = proc_keywords
-        proc_summ['version'] = proc_version
-        proc_summ['jobControlOptions'] = job_control
-        proc_summ['processDescriptionURL'] = proc_desc_url
+        proc_summ["id"] = proc_id
+        proc_summ["title"] = proc_title
+        proc_summ["abstract"] = proc_abstract
+        proc_summ["keywords"] = proc_keywords
+        proc_summ["version"] = proc_version
+        proc_summ["jobControlOptions"] = job_control
+        proc_summ["processDescriptionURL"] = proc_desc_url
 
         try:
             self._ades.deploy_proc(req_proc)
             sqlite_deploy_proc(req_proc)
         except Exception as ex:
-            print(f"Failed to create ADES required files for process deployment. {ex.message}")
+            print(
+                f"Failed to create ADES required files for process deployment. {ex.message}"
+            )
         return proc_summ
-            
+
     def undeploy_proc(self, proc_id):
-        #self._ades.undeploy_proc(proc_id)
+        # self._ades.undeploy_proc(proc_id)
         proc_desc = self.proc_dict(sqlite_undeploy_proc(proc_id))
         print("proc_desc: ", proc_desc)
         return proc_desc
@@ -130,9 +141,13 @@ class ADES_Base:
         print(ades_resp)
         job_info = dict()
         job_info["status"] = ades_resp["status"]
-        job_info = {"jobID": job_id, "status": job_info["status"], "message": "Status of job {}".format(job_id)}
+        job_info = {
+            "jobID": job_id,
+            "status": job_info["status"],
+            "message": "Status of job {}".format(job_id),
+        }
         # and update the db with that status
-        #(job_id, job_info["status"])
+        # (job_id, job_info["status"])
         return job_info
 
     def exec_job(self, proc_id, job_params):
@@ -147,17 +162,26 @@ class ADES_Base:
         # job_id = f"{proc_id}-{hashlib.sha1((json.dumps(job_inputs, sort_keys=True) + now).encode()).hexdigest()}"
         job_spec = {
             "proc_id": proc_id,
-            #"process": self.get_proc(proc_id),
-            "inputs": job_params
+            # "process": self.get_proc(proc_id),
+            "inputs": job_params,
         }
         ades_resp = self._ades.exec_job(job_spec)
-        job = Job(id=ades_resp['job_id'], status=ades_resp['status'], inputs=job_params["inputs"], outputs=[], tags={})
+        job = Job(
+            id=ades_resp["job_id"],
+            status=ades_resp["status"],
+            inputs=job_params["inputs"],
+            outputs=[],
+            tags={},
+        )
         self._job_publisher.publish_job_change(job)
-        # ades_resp will return platform specific information that should be 
+        # ades_resp will return platform specific information that should be
         # kept in the database with the job ID record
-        #sqlite_exec_job(proc_id, job_id, job_inputs, ades_resp)
-        return {"code": 201, "location": "{}/processes/{}/jobs/{}".format(self.host, proc_id, job.id)}
-            
+        # sqlite_exec_job(proc_id, job_id, job_inputs, ades_resp)
+        return {
+            "code": 201,
+            "location": "{}/processes/{}/jobs/{}".format(self.host, proc_id, job.id),
+        }
+
     def dismiss_job(self, proc_id, job_id):
         """
         Stop / Revoke Job
@@ -185,11 +209,7 @@ class ADES_Base:
                 if loc.startswith("s3://"):
                     location = loc
             # create output blocks and append
-            output = {
-                "mimeType": "tbd",
-                "href": location,
-                "id": id
-            }
+            output = {"mimeType": "tbd", "href": location, "id": id}
             outputs.append(output)
         job_result["outputs"] = outputs
         return job_result

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -33,7 +33,7 @@ class ADES_Base:
             raise ValueError("Platform {} not implemented.".\
                              format(self._platform))
         self._ades = ADES_Platform()
-        self._job_publisher = SnsJobPublisher()
+        self._job_publisher = SnsJobPublisher(app_config["JOB_NOTIFICATION_TOPIC_NAME"])
         
     def proc_dict(self, proc):
         return {"id": proc[0],
@@ -135,7 +135,7 @@ class ADES_Base:
         #(job_id, job_info["status"])
         return job_info
 
-    def exec_job(self, proc_id, job_inputs):
+    def exec_job(self, proc_id, job_params):
         """
         Execute algorithm
         :param proc_id: algorithm identifier
@@ -148,10 +148,10 @@ class ADES_Base:
         job_spec = {
             "proc_id": proc_id,
             #"process": self.get_proc(proc_id),
-            "inputs": job_inputs
+            "inputs": job_params
         }
         ades_resp = self._ades.exec_job(job_spec)
-        job = Job(id=ades_resp['id'], status=ades_resp['status'], inputs=job_inputs, outputs=[], tags={})
+        job = Job(id=ades_resp['job_id'], status=ades_resp['status'], inputs=job_params["inputs"], outputs=[], tags={})
         self._job_publisher.publish_job_change(job)
         # ades_resp will return platform specific information that should be 
         # kept in the database with the job ID record

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -149,7 +149,7 @@ class ADES_Base:
         job_id = ades_resp.get("job_id")
         # ades_resp will return platform specific information that should be 
         # kept in the database with the job ID record
-        #sqlite_exec_job(proc_id, job_id, job_inputs, ades_resp)
+        sqlite_exec_job(proc_id, job_id, job_inputs, ades_resp)
         return {"code": 201, "location": "{}/processes/{}/jobs/{}".format(self.host, proc_id, job_id)}
             
     def dismiss_job(self, proc_id, job_id):
@@ -160,10 +160,10 @@ class ADES_Base:
         :return:
         """
         ades_resp = self._ades.dismiss_job(proc_id, job_id)
-        if ades_resp is None:
+        if ades_resp.get("error") is None:
             job_spec = sqlite_dismiss_job(job_id)
         else:
-            job_spec = {"error": ades_resp}
+            job_spec = {"error": ades_resp.get("error")}
         return job_spec
 
     def get_job_results(self, proc_id, job_id):

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -360,7 +360,7 @@ class ADES_HYSDS(ADES_ABC):
             }
         except Exception as ex:
             error = ex
-            return {"job_id": hysds_job.job_id, "error": error}
+            return {"job_id": hysds_job.job_id, "error": str(error)}
 
     def dismiss_job(self, proc_id, job_id):
         # We can only dismiss jobs that were last in accepted or running state.

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -359,7 +359,7 @@ class ADES_HYSDS(ADES_ABC):
             }
         except Exception as ex:
             error = ex
-            return {"job_id": hysds_job.job_id, "error": error}
+            return {"job_id": hysds_job.job_id, "status": "failed", "error": error}
 
     def dismiss_job(self, proc_id, job_id):
         # We can only dismiss jobs that were last in accepted or running state.

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -360,7 +360,7 @@ class ADES_HYSDS(ADES_ABC):
             }
         except Exception as ex:
             error = ex
-            return {"job_id": hysds_job.job_id, "error": str(error)}
+            return {"job_id": hysds_job.job_id, "status": "failed", "error": str(error)}
 
     def dismiss_job(self, proc_id, job_id):
         # We can only dismiss jobs that were last in accepted or running state.

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -129,12 +129,12 @@ def processes_result(procID, jobID):
 def flask_wpst(app, debug=False, host="127.0.0.1",
                valid_platforms = ("Generic", "K8s", "PBS", "HYSDS")):
     platform = os.environ.get("ADES_PLATFORM", default="Generic")
-    job_notification_topic_name = os.environ.get("JOBS_DATA_SNS_TOPIC_ARN", default="unity-sps-job-status.fifo")
+    job_notification_topic_arn = os.environ.get("JOBS_DATA_SNS_TOPIC_ARN", default="unity-sps-job-status.fifo")
     if platform not in valid_platforms:
         raise ValueError("ADES_PLATFORM invalid - {} not in {}.".\
                          format(platform, valid_platforms))
     app.config["PLATFORM"] = platform
-    app.config["JOB_NOTIFICATION_TOPIC_NAME"] = job_notification_topic_name
+    app.config["JOB_NOTIFICATION_TOPIC_ARN"] = job_notification_topic_arn
     app.run(debug=debug, host=host)
 
 

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -129,10 +129,12 @@ def processes_result(procID, jobID):
 def flask_wpst(app, debug=False, host="127.0.0.1",
                valid_platforms = ("Generic", "K8s", "PBS", "HYSDS")):
     platform = os.environ.get("ADES_PLATFORM", default="Generic")
+    job_notification_topic_name = os.environ.get("JOB_NOTIFICATION_TOPIC_NAME", default="unity-sps-job-status.fifo")
     if platform not in valid_platforms:
         raise ValueError("ADES_PLATFORM invalid - {} not in {}.".\
                          format(platform, valid_platforms))
     app.config["PLATFORM"] = platform
+    app.config["JOB_NOTIFICATION_TOPIC_NAME"] = job_notification_topic_name
     app.run(debug=debug, host=host)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ cwl-runner==1.0
 docker==6.0.0
 jsonschema==4.5.1
 GitPython==3.1.29
+pydantic==1.10.7
+boto3==1.26.118

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.0.2
-requests==2.26.0
+requests==2.29.0
+urllib3==1.26.15
 pyyaml==5.4.1
 kubernetes==19.15.0
 cwltool==3.1.20211107152837

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jsonschema==4.5.1
 GitPython==3.1.29
 pydantic==1.10.7
 boto3==1.26.118
+backoff==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,7 @@ setup(
         "docker==6.0.0",
         "jsonschema==4.5.1",
         "GitPython==3.1.29",
+        "pydantic==1.10.7",
+        "boto3==1.26.118"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     },
     install_requires=[
         "Flask==2.0.2",
-        "requests==2.26.0",
+        "requests==2.29.0",
+        "urllib3==1.26.15",
         "pyyaml==5.4.1",
         "kubernetes==19.15.0",
         "cwltool==3.1.20211107152837",
@@ -25,6 +26,6 @@ setup(
         "jsonschema==4.5.1",
         "GitPython==3.1.29",
         "pydantic==1.10.7",
-        "boto3==1.26.118"
+        "boto3==1.26.118",
     ],
 )

--- a/utils/datatypes.py
+++ b/utils/datatypes.py
@@ -2,12 +2,6 @@ from pydantic import BaseModel
 from typing import List
 from enum import Enum
 
-class JobStatus(str, Enum):
-    accepted = "accepted"
-    running = "running"
-    failed = "failed"
-    succeeded = "succeeded"
-
 class Job(BaseModel):
     id: str
     status: str

--- a/utils/datatypes.py
+++ b/utils/datatypes.py
@@ -5,6 +5,6 @@ from enum import Enum
 class Job(BaseModel):
     id: str
     status: str
-    inputs: List[dict]
-    outputs: List[dict]
+    inputs: dict
+    outputs: dict
     tags: dict

--- a/utils/datatypes.py
+++ b/utils/datatypes.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List
+from enum import Enum
+
+class JobStatus(str, Enum):
+    accepted = "accepted"
+    running = "running"
+    failed = "failed"
+    succeeded = "succeeded"
+
+class Job(BaseModel):
+    id: str
+    status: str
+    inputs: List[dict]
+    outputs: List[dict]
+    tags: dict

--- a/utils/image_container_builder.py
+++ b/utils/image_container_builder.py
@@ -88,7 +88,7 @@ class ContainerImageBuilder:
 
         return image_url
 
-    def build_image(self):
+    def build_image(self, build_args=None):
         """
         Builds the Docker image
         :param tag: str; example, hello_world:develop
@@ -104,6 +104,7 @@ class ContainerImageBuilder:
                 rm=True,
                 tag=self.image_name_tag,
                 decode=True,
+                buildargs=build_args,
             )
         ]
         _process_output(output)

--- a/utils/job_publisher.py
+++ b/utils/job_publisher.py
@@ -12,15 +12,14 @@ class JobPublisher(metaclass=ABCMeta):
 class SnsJobPublisher(JobPublisher):
     def __init__(self, topic_arn: str):
         self.topic_arn = topic_arn
-        self.sts_client = boto3.client('sts', region_name='us-west-2')
 
     def publish_job_change(self, job: Job):
         client = boto3.client('sns', region_name='us-west-2')
-        try:
-            client.publish(
-                TopicArn=self.topic_arn,
-                Message=job.json(),
-                MessageGroupId=job.id
-            )
-        except Exception as e:
-            print(f"Failed to publish job {job.id} to {self.topic_arn}:\n {e}")
+        #try:
+        client.publish(
+            TopicArn=self.topic_arn,
+            Message=job.json(),
+            MessageGroupId=job.id
+        )
+        # except Exception as e:
+        #     print(f"Failed to publish job {job.id} to {self.topic_arn}:\n {e}")

--- a/utils/job_publisher.py
+++ b/utils/job_publisher.py
@@ -1,23 +1,25 @@
 from abc import ABCMeta, abstractmethod
-from utils.datatypes import Job, JobStatus
+from utils.datatypes import Job
 import boto3
 
 class JobPublisher(metaclass=ABCMeta):
 
     @abstractmethod
-    def publish_job_change(self, job: Job, status: JobStatus):
+    def publish_job_change(self, job: Job):
         raise NotImplementedError()
 
 class SnsJobPublisher(JobPublisher):
-    def __init__(self, topic_name: str):
-        self.topic_name = topic_name
+    def __init__(self, topic_arn: str):
+        self.topic_arn = topic_arn
         self.sts_client = boto3.client('sts', region_name='us-west-2')
-        self.topic_arn = f"arn:aws:sns:{self.sts_client.meta.region_name}:{self.sts_client.get_caller_identity()['Account']}:{self.topic_name}"
 
     def publish_job_change(self, job: Job):
         client = boto3.client('sns', region_name='us-west-2')
-        client.publish(
-            TopicArn=self.topic_arn,
-            Message=job.json(),
-            MessageGroupId="jobstatus"
-        )
+        try:
+            client.publish(
+                TopicArn=self.topic_arn,
+                Message=job.json(),
+                MessageGroupId=job.id
+            )
+        except Exception as e:
+            print(f"Failed to publish job {job.id} to {self.topic_arn}:\n {e}")

--- a/utils/job_publisher.py
+++ b/utils/job_publisher.py
@@ -2,22 +2,19 @@ from abc import ABCMeta, abstractmethod
 from utils.datatypes import Job, JobStatus
 import boto3
 
-class JobPublisher(metaclass=ABCMeta):
 
+class JobPublisher(metaclass=ABCMeta):
     @abstractmethod
     def publish_job_change(self, job: Job, status: JobStatus):
         raise NotImplementedError()
 
+
 class SnsJobPublisher(JobPublisher):
-    def __init__(self, topic_name: str):
-        self.topic_name = topic_name
-        self.sts_client = boto3.client('sts', region_name='us-west-2')
-        self.topic_arn = f"arn:aws:sns:{self.sts_client.meta.region_name}:{self.sts_client.get_caller_identity()['Account']}:{self.topic_name}"
+    def __init__(self, topic_arn: str):
+        self.topic_arn = topic_arn
 
     def publish_job_change(self, job: Job):
-        client = boto3.client('sns', region_name='us-west-2')
+        client = boto3.client("sns", region_name="us-west-2")
         client.publish(
-            TopicArn=self.topic_arn,
-            Message=job.json(),
-            MessageGroupId="jobstatus"
+            TopicArn=self.topic_arn, Message=job.json(), MessageGroupId="jobstatus"
         )

--- a/utils/job_publisher.py
+++ b/utils/job_publisher.py
@@ -1,0 +1,23 @@
+from abc import ABCMeta, abstractmethod
+from utils.datatypes import Job, JobStatus
+import boto3
+
+class JobPublisher(metaclass=ABCMeta):
+
+    @abstractmethod
+    def publish_job_change(self, job: Job, status: JobStatus):
+        raise NotImplementedError()
+
+class SnsJobPublisher(JobPublisher):
+    def __init__(self, topic_name: str):
+        self.topic_name = topic_name
+        self.sts_client = boto3.client('sts', region_name='us-west-2')
+        self.topic_arn = f"arn:aws:sns:{self.sts_client.meta.region_name}:{self.sts_client.get_caller_identity()['Account']}:{self.topic_name}"
+
+    def publish_job_change(self, job: Job):
+        client = boto3.client('sns', region_name='us-west-2')
+        client.publish(
+            TopicArn=self.topic_arn,
+            Message=job.json(),
+            MessageGroupId="jobstatus"
+        )


### PR DESCRIPTION
## Purpose
- This PR merges in changes made for the 23.2 release. It includes support for job notifications, docker build args, and partially working dismiss job support
## Proposed Changes
- [ADD] Job notifications through SNS
- [ADD] Pass args at docker build time
- [ADD] dismiss job initial implementation with bugs
- [CHANGE] exec_job to use exponential backoff polling instead of static wait time for hysds job status
## Testing
- Changes were tested by deploying and running [regression test suite](https://github.com/unity-sds/unity-sps-prototype/actions/runs/5405749928/jobs/9821728225)
