### PR TITLE
Add support for job labels

### DIFF
--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -10,7 +10,6 @@ from flask_ades_wpst.ades_abc import ADES_ABC
 import otello
 from otello import Mozart
 import requests
-import time
 import traceback
 import backoff
 
@@ -369,7 +368,9 @@ class ADES_HYSDS(ADES_ABC):
             labels = job_spec["inputs"]["labels"]
         else:
             labels = []
+
         print("Submitting job of type job-{}\n Parameters: {}".format(proc_id, params))
+
         try:
             # Publish job to JobPublisher passed in the job_spec
             hysds_job = job.submit_job(queue="verdi-job_worker", priority=0, tag="test")
@@ -377,9 +378,10 @@ class ADES_HYSDS(ADES_ABC):
                 id=hysds_job.job_id,
                 status="submitted",
                 inputs=params,
-                outputs=[],
+                outputs={},
                 labels=labels,
             )
+
             job_spec["job_publisher"].publish_job_change(job)
 
             print(f"Submitted job with id {hysds_job.job_id}")
@@ -398,12 +400,12 @@ class ADES_HYSDS(ADES_ABC):
                     id=hysds_job.id,
                     status="failed",
                     inputs=params,
-                    outputs=[],
+                    outputs={},
                     labels=labels,
                 )
                 job_spec["job_publisher"].publish_job_change(job)
             except (AttributeError, UnboundLocalError) as e:
-                print("Failed to publish job, no hysds job id:\n{e}")
+                print(f"Failed to publish job, no hysds job id:\n{e}")
 
             error = ex
             return {"job_id": hysds_job.job_id, "status": "failed", "inputs": params, "error": str(error)}

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -364,6 +364,11 @@ class ADES_HYSDS(ADES_ABC):
             for input in job_spec.get("inputs").get("inputs"):
                 params[input["id"]] = input["data"]
         job.set_input_params(params=params)
+
+        if "labels" in job_spec["inputs"]:
+            labels = job_spec["inputs"]["labels"]
+        else:
+            labels = []
         print("Submitting job of type job-{}\n Parameters: {}".format(proc_id, params))
         try:
             # Publish job to JobPublisher passed in the job_spec
@@ -373,7 +378,7 @@ class ADES_HYSDS(ADES_ABC):
                 status="submitted",
                 inputs=params,
                 outputs=[],
-                tags={},
+                labels=labels,
             )
             job_spec["job_publisher"].publish_job_change(job)
 
@@ -394,7 +399,7 @@ class ADES_HYSDS(ADES_ABC):
                     status="failed",
                     inputs=params,
                     outputs=[],
-                    tags={},
+                    labels=labels,
                 )
                 job_spec["job_publisher"].publish_job_change(job)
             except (AttributeError, UnboundLocalError) as e:

--- a/utils/datatypes.py
+++ b/utils/datatypes.py
@@ -7,4 +7,4 @@ class Job(BaseModel):
     status: str
     inputs: dict
     outputs: dict
-    tags: dict
+    labels: List[str]


### PR DESCRIPTION
## Purpose
- Update job data type and job publish step to support job labels
## Proposed Changes
- [CHANGE] tag field in Job to labels
- [ADD] check for optional labels field in job exec request body
## Testing
- Elasticsearch label propagation was validated manually with jobs that had:
1. No label field
2. A label field that contained an empty list
3. A label field with string labels
- validated that updates [pass regression tests](https://github.com/unity-sds/unity-sps-prototype/actions/runs/5604169321)
