### PR TITLE
#155: Return of outputs from a WPS-T Job Results request

### DIFF
--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -67,9 +67,9 @@ class ADES_Base:
         return sts_client, client
 
     def _update_jobs_database(self, job_id, proc_id, job_inputs={}, job_tags=[]):
-        sts_client, sns_client = self.get_sts_and_sns_clients(aws_auth_method)
+        sts_client, sns_client = self.get_sts_and_sns_clients(aws_auth_method="iam")
         job_data = {"id": job_id, "process": proc_id, "status": "Accepted", "inputs": job_inputs, "tags": job_tags}
-
+        # TOOD: Figure out how to get topic_arn
         print(
             sns_client.publish(
                 TopicArn=topic_arn, Message=json.dumps(job_data), MessageGroupId=job_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ docker==6.0.0
 jsonschema==4.5.1
 GitPython==3.1.29
 boto3==1.26.97
+elasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ cwl-runner==1.0
 docker==6.0.0
 jsonschema==4.5.1
 GitPython==3.1.29
+boto3==1.26.97


### PR DESCRIPTION
## Purpose
- Update WPS-T API job endpoints to use Jobs DB for execute and getResult endpoints.
## Proposed Changes
- [CHANGE]
   - On successful job submission, add following job details to Jobs DB:
       - Job ID
       - Process ID
       - Status (set to Accepted, if successfully submitted to ADES)
       - Inputs
       - Job Tags
- On request of Job Result, query AWS ES and parse outputs to return products information.
## Issues
- https://github.com/unity-sds/unity-sps-prototype/issues/155

## Testing
- Provide some proof you've tested your changes 
- Example: test results available at ...
- Example: tested on operating system ...
