### PR TITLE
Job configuration inputs through workflows

### DIFF
--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -168,9 +168,9 @@ class ADES_Base:
         # job_id = f"{proc_id}-{hashlib.sha1((json.dumps(job_inputs, sort_keys=True) + now).encode()).hexdigest()}"
 
         # TODO: relying on backend for job id means we need to pass the job publisher to backend impl code for submit notification
-        # job notifications should originate from this base layer once 
+        # job notifications should originate from this base layer once  
         job_params["inputs"] += [{"id": "jobs_data_sns_topic_arn",
-                                  "data": os.getenv("JOB_DATA_SNS_TOPIC_ARN")},
+                                  "data": os.getenv("JOBS_DATA_SNS_TOPIC_ARN")},
                                  {"id": "dapa_api",
                                   "data": os.getenv("DAPA_API")},
                                  {"id": "client_id",

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -106,7 +106,7 @@ class ADES_Base:
         proc_summ["processDescriptionURL"] = proc_desc_url
 
         # add unity-sps workflow step inputs to process inputs
-        req_proc["processDescription"]["process"]["inputs"] += [{"id": key for key in self._job_config_inputs.keys()}]
+        req_proc["processDescription"]["process"]["inputs"] += [{"id": key} for key in self._job_config_inputs.keys()]
 
         try:
             self._ades.deploy_proc(req_proc)

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -1,3 +1,4 @@
+import os
 from flask import Response
 from jinja2 import Template
 import logging
@@ -97,6 +98,12 @@ class ADES_Base:
         proc_summ["jobControlOptions"] = job_control
         proc_summ["processDescriptionURL"] = proc_desc_url
 
+        # add unity-sps workflow step inputs to process inputs
+        req_proc["processDescription"]["process"]["inputs"] += [{"id": "jobs_data_sns_topic_arn"},
+                                                                {"id": "dapa_api"},
+                                                                {"id": "client_id"},
+                                                                {"id": "staging_bucket"}]
+
         try:
             self._ades.deploy_proc(req_proc)
             sqlite_deploy_proc(req_proc)
@@ -162,6 +169,14 @@ class ADES_Base:
 
         # TODO: relying on backend for job id means we need to pass the job publisher to backend impl code for submit notification
         # job notifications should originate from this base layer once 
+        job_params["inputs"] += [{"id": "jobs_data_sns_topic_arn",
+                                  "data": os.getenv("JOB_DATA_SNS_TOPIC_ARN")},
+                                 {"id": "dapa_api",
+                                  "data": os.getenv("DAPA_API")},
+                                 {"id": "client_id",
+                                  "data": os.getenv("CLIENT_ID")},
+                                 {"id": "staging_bucket",
+                                  "data": os.getenv("STAGING_BUCKET")}]
         job_spec = {
             "proc_id": proc_id,
             # "process": self.get_proc(proc_id),

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -186,15 +186,9 @@ class ADES_Base:
         }
         ades_resp = self._ades.exec_job(job_spec)
 
-        # recontstruct inputs without _job_config_inputs before putting in database
-        db_inputs = []
-        for ades_input in ades_resp["inputs"]:
-            # only add inputs from the response that aren't in the _job_config_inputs
-            if not ades_input["name"] in self._job_config_inputs:
-                db_inputs.append(ades_input)
         # ades_resp will return platform specific information that should be
         # kept in the database with the job ID record
-        sqlite_exec_job(proc_id, ades_resp["job_id"], db_inputs, ades_resp)
+        sqlite_exec_job(proc_id, ades_resp["job_id"], ades_resp["inputs"], ades_resp)
         return {"code": 201, "location": "{}/processes/{}/jobs/{}".format(self.host, proc_id, ades_resp["job_id"])}
             
     def dismiss_job(self, proc_id, job_id):

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -269,13 +269,7 @@ class ADES_HYSDS(ADES_ABC):
             cb.validate_hysds_ios()
             cb.validate_job_specs()
 
-            build_args = {
-                "STAGING_BUCKET": "",
-                "CLIENT_ID": "",
-                "DAPA_API": "",
-                "JOBS_DATA_SNS_TOPIC_ARN": "",
-            }
-            cb.build_image(build_args=build_args)
+            cb.build_image()
             image_url = cb.push_image()
 
             cb.publish_job_spec()

--- a/flask_ades_wpst/ades_hysds.py
+++ b/flask_ades_wpst/ades_hysds.py
@@ -270,10 +270,10 @@ class ADES_HYSDS(ADES_ABC):
             cb.validate_job_specs()
 
             build_args = {
-                "STAGING_BUCKET": os.getenv("STAGING_BUCKET"),
-                "CLIENT_ID": os.getenv("CLIENT_ID"),
-                "DAPA_API": os.getenv("DAPA_API"),
-                "JOBS_DATA_SNS_TOPIC_ARN": os.getenv("JOBS_DATA_SNS_TOPIC_ARN"),
+                "STAGING_BUCKET": "",
+                "CLIENT_ID": "",
+                "DAPA_API": "",
+                "JOBS_DATA_SNS_TOPIC_ARN": "",
             }
             cb.build_image(build_args=build_args)
             image_url = cb.push_image()


### PR DESCRIPTION
## Purpose
Changes to propagate job configuration workflow inputs through job inputs instead of through process image environment variables.

## Proposed Changes
- [ADD] Add `_job_config_inputs` instance variable to `ades_base` which maps job config workflow inputs to environment variable names in the WPS-T
- [ADD] a step for adding `_job_config_inputs` keys as params to process deploy requests in `ades_base`
- [ADD] a step for adding `_job_config_inputs` values as param arguments to job execution requests in `ades_base`
- [REMOVE] build args from image build

## Issues
- fixes bug #230 where domain specific images were causing issues between venues

## Testing
- validated execution chirp workflow works with changes
- ran passing regression tests in MCP-Dev
